### PR TITLE
Make physicalFileSystem more robust so it can apply out of an object …

### DIFF
--- a/net45/owin/StaticFilesSample/Startup.cs
+++ b/net45/owin/StaticFilesSample/Startup.cs
@@ -11,13 +11,15 @@ namespace StaticFilesSample
         {
 #if DEBUG
             app.UseErrorPage();
+
+            PhysicalFileSystem defaultFS = new PhysicalFileSystem(@".\defaults");
 #endif
             // Remap '/' to '.\defaults\'.
             // Turns on static files and default files.
             app.UseFileServer(new FileServerOptions()
             {
                 RequestPath = PathString.Empty,
-                FileSystem = new PhysicalFileSystem(@".\defaults"),
+                FileSystem = defaultFS,
             });
 
             // Only serve files requested by name.


### PR DESCRIPTION
Currently the owin rule for PhysicalFileSystem replacement is limited to only object expressions syntax. We should check in normal expressions as well.