### PR TITLE
Add new apis for Cookies and QueryString

### DIFF
--- a/net45/owin/AspNetRoutes/OwinApp2.cs
+++ b/net45/owin/AspNetRoutes/OwinApp2.cs
@@ -8,6 +8,13 @@ namespace AspNetRoutes
         // Invoked once per request.
         public static Task Invoke(IOwinContext context)
         {
+            RequestCookieCollection cookies = context.Request.Cookies;
+            string owinCookieValue = cookies["OwinCookieKey"];
+
+            context.Request.QueryString = new QueryString("owin", "owinValue");
+            IReadableStringCollection stringquery = context.Request.Query;
+            string owinquery = stringquery["owin"];
+
             context.Response.ContentType = "text/plain";
             return context.Response.WriteAsync("Hello World 2");
         }

--- a/net45/owin/AspNetRoutes/Startup.cs
+++ b/net45/owin/AspNetRoutes/Startup.cs
@@ -15,6 +15,9 @@ namespace AspNetRoutes
         // Invoked once per request.
         public Task Invoke(IOwinContext context)
         {
+            ResponseCookieCollection cookies = context.Response.Cookies;
+            cookies.Append("OwinCookieKey", "OwinCookieValue");
+
             context.Response.ContentType = "text/plain";
             return context.Response.WriteAsync("Hello World");
         }


### PR DESCRIPTION
Currently there is no rules for porting Microsoft,Owin.IReadableStringCollection and Microsoft.Owin.RequestCookieCollection  and Microsoft.Owin.ResponseCookieCollection. We should add api for those and create rules to port them.