### PR TITLE
Added two cases for CastingExpressionIdentifier and Using directive

### DIFF
--- a/net472/webapi/BuildableWebApi/BuildableWebApi/Controllers/DataReadController.cs
+++ b/net472/webapi/BuildableWebApi/BuildableWebApi/Controllers/DataReadController.cs
@@ -3,6 +3,9 @@ using System.Web.Http.OData;
 
 namespace BuildableWebApi.Controllers
 {
+    using System.Web.Http;
+    using System.Web.Http.OData;
+
     public class DataReadController : ApiController
     {
         [HttpGet]
@@ -10,7 +13,7 @@ namespace BuildableWebApi.Controllers
         [Route("")]
         public IHttpActionResult Get()
         {
-            return Ok();
+            return (IHttpActionResult)Ok();
         }
     }
 }


### PR DESCRIPTION
Added two missing test cases:
1. CastingExpressionSyntax should be included when dealing with identifier replace actions.
2. Some developers choose to write using directives inside namespace block.